### PR TITLE
Add concurrency option for batch testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - JSON/YAML配置檔案支援
 - 批次執行多個測試案例
 - 支援自定義headers和認證
+- 可設定同時執行的測試數量
 - 詳細的測試統計和報告
 
 ### 📊 報告生成
@@ -70,6 +71,9 @@ uv run python comprehensive_api_tester.py batch tests.json --html-report
 
 # 指定輸出檔案
 uv run python comprehensive_api_tester.py batch tests.json --output my_report.json
+
+# 設定同時執行的測試數量
+uv run python comprehensive_api_tester.py batch tests.json --concurrency 4
 ```
 
 ### 📝 生成範例配置檔案

--- a/comprehensive_api_tester.py
+++ b/comprehensive_api_tester.py
@@ -65,7 +65,7 @@ def run_batch_test(args):
     print(f"📋 批次測試模式: {args.config_file}")
     
     try:
-        tester = BatchTester(args.config_file)
+        tester = BatchTester(args.config_file, max_workers=args.concurrency)
         tester.run_batch_tests()
         
         # 生成JSON報告
@@ -193,6 +193,7 @@ def main():
     batch_parser.add_argument('config_file', help='測試配置檔案 (JSON/YAML)')
     batch_parser.add_argument('--output', help='輸出報告檔案名稱')
     batch_parser.add_argument('--html-report', action='store_true', help='生成HTML報告')
+    batch_parser.add_argument('--concurrency', type=int, default=1, help='同時測試的執行緒數')
     
     # 建立範例檔案指令
     samples_parser = subparsers.add_parser('create-samples', help='建立範例配置檔案')


### PR DESCRIPTION
## Summary
- enable threaded execution in `BatchTester`
- allow CLI to specify concurrency for batch tests
- document concurrency option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684903aeab4c832fac324e5a5df10fa2